### PR TITLE
Update vue-feather-icons docs site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install --save-dev svelte-feather-icons
 <AtSignIcon size="1.5x" />
 ```
 
-See all icons and usage here: https://vue-feather-icons.netlify.com
+See all icons and usage here: https://vue-feather-icons.egoist.sh/
 
 ## Author
 


### PR DESCRIPTION
The vue-feather-icons package docs site is now hosted in a different place. This PR is updating the link in the README to the new, correct one. 