### PR TITLE
Fix peer dependencies & deprecations

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,19 +26,20 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
+    "@rollup/plugin-terser": "^0.4.3",
     "feather-icons": "4.29.0",
     "fs-extra": "^10.0.0",
     "pascal-case": "^3.1.2",
     "path": "^0.12.7",
     "rollup": "^2",
     "rollup-plugin-svelte": "^7.1.5",
-    "rollup-plugin-terser": "^7.0.2"
+    "svelte": "^3.38.2"
   },
   "keywords": [
     "svelte",
     "feather icons"
   ],
-  "dependencies": {
-    "svelte": "^3.38.2"
+  "peerDependencies": {
+    "svelte": "^3.38.2 || ^4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
 import svelte from 'rollup-plugin-svelte';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 
 import pkg from './package.json';


### PR DESCRIPTION
The required Svelte dependency isn't correctly used: it should be installed as a dev _and_ a peer dependency, not as a regular dependency. With the current state of your repo, it forces the user to install your exact version of Svelte, `3.38.2`, alongside their own project's version of Svelte, leading to a duplicate. You can check [prettier-plugin-svelte/package.json](https://github.com/sveltejs/prettier-plugin-svelte/blob/b269610ce65de5a8e1c7699c39f24076b00a2bdb/package.json#L54) or [svelte-eslint-parser/package.json](https://github.com/sveltejs/svelte-eslint-parser/blob/a4d31f07f5c93057e276fa804d4e2b267264dc0f/package.json#L48) as examples.

This PR fixes this, by enforcing a Svelte version selector that accepts basically anything inclusively above `3.38.2`.
Also, I replaced `rollup-plugin-terser` with `@rollup/plugin-terser`, because the one you're using is now deprecated.

All the changes have been tested by running successful `npm i` and `npm run build`.