### PR TITLE
Change SvelteComponentTyped to SvelteComponent

### DIFF
--- a/build.js
+++ b/build.js
@@ -36,8 +36,8 @@ Promise.all(icons.map(icon => {
   const main = icons
     .map(icon => `export { default as ${icon.pascalCasedComponentName} } from './icons/${icon.pascalCasedComponentName}.svelte'`)
     .join('\n\n')
-  const types = '/// <reference types="svelte" />\nimport {SvelteComponentTyped} from "svelte/internal"\n' +
-    icons.map(icon => `export class ${icon.pascalCasedComponentName} extends SvelteComponentTyped<{size?: string, strokeWidth?: number, class?: string}> {}`).join("\n")
+  const types = '/// <reference types="svelte" />\nimport {SvelteComponent} from "svelte"\n' +
+    icons.map(icon => `export class ${icon.pascalCasedComponentName} extends SvelteComponent<{size?: string, strokeWidth?: number, class?: string}> {}`).join("\n")
   await fs.outputFile("index.d.ts", types, 'utf8');
   return await fs.outputFile('./src/index.js', main, 'utf8')
 })

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "description": "Feather icons for Svelte (Completely based on vue-feather-icons by EGOIST)",
   "version": "4.1.0",
   "author": "dylanblokhuis <dylanblokhuis3@hotmail.com>",
-  "contributors": [
-    "Marko Calasan <calasanmarko@hotmail.com>"
-  ],
   "repository": {
     "url": "dylanblokhuis/svelte-feather-icons",
     "type": "git"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@calasanmarko/svelte-feather-icons",
+  "name": "svelte-feather-icons",
   "description": "Feather icons for Svelte (Completely based on vue-feather-icons by EGOIST)",
   "version": "4.1.0",
   "author": "dylanblokhuis <dylanblokhuis3@hotmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "svelte-feather-icons",
+  "name": "@calasanmarko/svelte-feather-icons",
   "description": "Feather icons for Svelte (Completely based on vue-feather-icons by EGOIST)",
   "version": "4.1.0",
   "author": "dylanblokhuis <dylanblokhuis3@hotmail.com>",
+  "contributors": [
+    "Marko Calasan <calasanmarko@hotmail.com>"
+  ],
   "repository": {
     "url": "dylanblokhuis/svelte-feather-icons",
     "type": "git"


### PR DESCRIPTION
See issue https://github.com/dylanblokhuis/svelte-feather-icons/issues/26.

Typescript and svelte-check complain when using `SvelteComponentTyped` instead of `SvelteComponent`, probably related to the [deprecation of the former](https://svelte.dev/docs/v4-migration-guide#sveltecomponenttyped-is-deprecated).

This PR changes the build script to use `SvelteComponent`.